### PR TITLE
Add ATM locator tool for Hong Kong retail banks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is an MCP server that provides access to finance related data in Hong Kong 
 5. Get list of hotlines for reporting loss of credit card from Hong Kong banks
 6. Get information of Tender Invitation and Notice of Award of Contracts from Hong Kong Monetary Authority
 7. Daily figures of Hong Kong Interbank Interest Rates (HIBOR)
+8. Information on Automated Teller Machines (ATMs) of retail banks in Hong Kong
 
 ## Examples
 
@@ -22,6 +23,7 @@ This is an MCP server that provides access to finance related data in Hong Kong 
 * Write a commentary about the latest residential mortgage loans in negative equity in Hong Kong
 * How is current Hong Kong economy by referencing credit lending data and residential mortgage loans in negative equity?
 * What are the recent trends in HIBOR rates over the past month?
+* Where can I find ATMs in Yuen Long district that support HKD and RMB currencies?
 
 Assume chart tool is available:
 

--- a/hkopenai/hk_finance_mcp_server/__init__.py
+++ b/hkopenai/hk_finance_mcp_server/__init__.py
@@ -1,5 +1,6 @@
 """Hong Kong Finance MCP Server package."""
 from .server import main
+from . import tool_atm_locator
 
 __version__ = "0.1.0"
-__all__ = ['main']
+__all__ = ['main', 'tool_atm_locator']

--- a/hkopenai/hk_finance_mcp_server/server.py
+++ b/hkopenai/hk_finance_mcp_server/server.py
@@ -6,6 +6,7 @@ from hkopenai.hk_finance_mcp_server import tool_credit_card
 from hkopenai.hk_finance_mcp_server import tool_coin_cart
 from hkopenai.hk_finance_mcp_server import tool_hkma_tender
 from hkopenai.hk_finance_mcp_server import tool_hibor_daily
+from hkopenai.hk_finance_mcp_server import tool_atm_locator
 from typing import Dict, Annotated, Optional, List
 from pydantic import Field
 
@@ -87,6 +88,17 @@ def create_mcp_server():
         end_date: Annotated[Optional[str], Field(description="End date (YYYY-MM-DD)")] = None
     ) -> List[Dict]:
         return tool_hibor_daily.get_hibor_stats(start_date, end_date)
+
+    @mcp.tool(
+        description="Get information on Automated Teller Machines (ATMs) of retail banks in Hong Kong"
+    )
+    def get_atm_locations(
+        district: Annotated[Optional[str], Field(description="District name to filter results")] = None,
+        bank_name: Annotated[Optional[str], Field(description="Bank name to filter results")] = None,
+        pagesize: Annotated[Optional[int], Field(description="Number of records per page")] = 100,
+        offset: Annotated[Optional[int], Field(description="Starting record offset")] = 0
+    ) -> List[Dict]:
+        return tool_atm_locator.get_atm_locations(district, bank_name, pagesize, offset)
 
     return mcp
 

--- a/hkopenai/hk_finance_mcp_server/tool_atm_locator.py
+++ b/hkopenai/hk_finance_mcp_server/tool_atm_locator.py
@@ -1,0 +1,61 @@
+import json
+import urllib.request
+from typing import List, Dict, Optional
+
+def fetch_atm_locator_data(
+    district: Optional[str] = None,
+    bank_name: Optional[str] = None,
+    pagesize: Optional[int] = 100,
+    offset: Optional[int] = 0
+) -> List[Dict]:
+    """Fetch and parse ATM locator data from HKMA API
+    
+    Args:
+        district: Optional district name to filter results
+        bank_name: Optional bank name to filter results
+        pagesize: Number of records per page (default: 100)
+        offset: Offset for pagination (default: 0)
+        
+    Returns:
+        List of ATM location data in JSON format
+    """
+    url = f"https://api.hkma.gov.hk/public/bank-svf-info/banks-atm-locator?lang=en&pagesize={pagesize}&offset={offset}"
+    response = urllib.request.urlopen(url)
+    data = json.loads(response.read().decode('utf-8'))
+    
+    records = data.get('result', {}).get('records', [])
+    filtered_records = []
+    
+    for record in records:
+        if district and record.get('district', '').lower() != district.lower():
+            continue
+        if bank_name and record.get('bank_name', '').lower() != bank_name.lower():
+            continue
+        filtered_records.append({
+            'district': record.get('district', ''),
+            'bank_name': record.get('bank_name', ''),
+            'type_of_machine': record.get('type_of_machine', ''),
+            'function': record.get('function', ''),
+            'currencies_supported': record.get('currencies_supported', ''),
+            'barrier_free_access': record.get('barrier_free_access', ''),
+            'network': record.get('network', ''),
+            'address': record.get('address', ''),
+            'service_hours': record.get('service_hours', ''),
+            'latitude': float(record.get('latitude', 0.0)),
+            'longitude': float(record.get('longitude', 0.0))
+        })
+    
+    return filtered_records
+
+def get_atm_locations(
+    district: Optional[str] = None,
+    bank_name: Optional[str] = None,
+    pagesize: Optional[int] = 100,
+    offset: Optional[int] = 0
+) -> List[Dict]:
+    """Retrieve ATM locations with optional filtering"""
+    data = fetch_atm_locator_data(district, bank_name, pagesize, offset)
+    
+    if not data:
+        return []
+    return data

--- a/tests/test_integration_tool_atm_locator.py
+++ b/tests/test_integration_tool_atm_locator.py
@@ -1,0 +1,21 @@
+import unittest
+from hkopenai.hk_finance_mcp_server import tool_atm_locator
+
+class TestAtmLocatorIntegration(unittest.TestCase):
+    def test_fetch_atm_locator_data_integration(self):
+        result = tool_atm_locator.fetch_atm_locator_data(pagesize=5, offset=0)
+        
+        self.assertTrue(len(result) > 0, "Expected to fetch at least one ATM record")
+        self.assertIn('district', result[0], "Expected 'district' field in result")
+        self.assertIn('bank_name', result[0], "Expected 'bank_name' field in result")
+        self.assertIn('address', result[0], "Expected 'address' field in result")
+
+    def test_fetch_atm_locator_data_with_district_filter(self):
+        result = tool_atm_locator.fetch_atm_locator_data(district="YuenLong", pagesize=5, offset=0)
+        
+        self.assertTrue(len(result) > 0, "Expected to fetch at least one ATM record in YuenLong")
+        for record in result:
+            self.assertEqual(record['district'].lower(), "yuenlong", "Expected all results to be from YuenLong district")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tool_atm_locator.py
+++ b/tests/test_tool_atm_locator.py
@@ -1,0 +1,55 @@
+import unittest
+import json
+from unittest.mock import patch, Mock
+from hkopenai.hk_finance_mcp_server import tool_atm_locator
+
+class TestAtmLocatorTool(unittest.TestCase):
+    def setUp(self):
+        self.sample_data = {
+            "result": {
+                "records": [
+                    {
+                        "district": "YuenLong",
+                        "bank_name": "Industrial and Commercial Bank of China (Asia) Limited",
+                        "type_of_machine": "Automatic Teller Machine",
+                        "function": "Cash withdrawal, Cardless withdrawal",
+                        "currencies_supported": "HKD, RMB",
+                        "barrier_free_access": "Voice navigation, Suitable height ATM for wheelchair users",
+                        "network": "JETCO, PLUS, CIRRUS, CUP, VISA, MASTER, DISCOVER, DINER",
+                        "address": "No.7, 2/F, T Town South, Tin Chung Court, 30 Tin Wah Road, Tin Shui Wai, Yuen Long, N.T.",
+                        "service_hours": "24 hours",
+                        "latitude": "22.461655",
+                        "longitude": "113.997757"
+                    }
+                ]
+            }
+        }
+
+    @patch('urllib.request.urlopen')
+    def test_fetch_atm_locator_data(self, mock_urlopen):
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps(self.sample_data).encode('utf-8')
+        mock_urlopen.return_value = mock_response
+
+        result = tool_atm_locator.fetch_atm_locator_data(pagesize=1, offset=0)
+        
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['district'], "YuenLong")
+        self.assertEqual(result[0]['bank_name'], "Industrial and Commercial Bank of China (Asia) Limited")
+
+    @patch('urllib.request.urlopen')
+    def test_fetch_atm_locator_data_with_filters(self, mock_urlopen):
+        mock_response = Mock()
+        mock_response.read.return_value = json.dumps(self.sample_data).encode('utf-8')
+        mock_urlopen.return_value = mock_response
+
+        result = tool_atm_locator.fetch_atm_locator_data(district="YuenLong", bank_name="Industrial and Commercial Bank of China (Asia) Limited", pagesize=1, offset=0)
+        
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['district'], "YuenLong")
+
+        result = tool_atm_locator.fetch_atm_locator_data(district="Central", pagesize=1, offset=0)
+        self.assertEqual(len(result), 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request adds a new tool to fetch information on Automated Teller Machines (ATMs) of retail banks in Hong Kong. It includes the implementation, test files, and updates to the README.md. Closes #3